### PR TITLE
XP9 Compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 
 language: php
 
+dist: trusty
+
 php:
   - 5.6
   - 7.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,10 @@ URI handling change log
 
 ## ?.?.? / ????-??-??
 
+## 1.0.0 / 2017-06-04
+
+* Added forward compatibility with XP 9.0.0 - @thekid
+
 ## 0.5.0 / 2017-03-26
 
 * Added `asPath()` method to convert URIs to file paths

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
   "description" : "URIs",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^8.0 | ^7.0",
+    "xp-framework/core": "^9.0 | ^8.0 | ^7.0",
     "php" : ">=5.6.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^7.0"
+    "xp-framework/unittest": "^9.0 | ^8.0 | ^7.0"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]


### PR DESCRIPTION
Made compatible simply by updating composer.json. As library has been in production use in the meantime, bumping version to 1.0