### PR TITLE
Make path() accept arrays which are joined together

### DIFF
--- a/src/main/php/util/uri/Creation.class.php
+++ b/src/main/php/util/uri/Creation.class.php
@@ -128,7 +128,8 @@ class Creation {
   }
 
   /**
-   * Sets path (use NULL to remove), encoding by default
+   * Sets path (use NULL to remove), encoding by default. Multiple paths
+   * are joined together
    *
    * @param  string|string[] $value
    * @param  bool $encode

--- a/src/main/php/util/uri/Creation.class.php
+++ b/src/main/php/util/uri/Creation.class.php
@@ -1,9 +1,9 @@
 <?php namespace util\uri;
 
-use util\URI;
+use lang\IllegalStateException;
 use util\Authority;
 use util\Secret;
-use lang\IllegalStateException;
+use util\URI;
 
 /**
  * Creates URI instances 
@@ -130,12 +130,24 @@ class Creation {
   /**
    * Sets path (use NULL to remove), encoding by default
    *
-   * @param  string $value
+   * @param  string|string[] $value
    * @param  bool $encode
    * @return self
    */
   public function path($value, $encode= true) {
-    $this->path= null === $value || !$encode ? $value : $this->escape($value, '@+/:', 'rawurlencode');
+    if (null === $value) {
+      $this->path= null;
+    } else if (is_array($value)) {
+      $this->path= '';
+      foreach ($value as $path) {
+        $this->path= rtrim($this->path, '/').'/'.($encode
+          ? $this->escape(ltrim($path, '/'), '@+/:', 'rawurlencode')
+          : ltrim($path, '/')
+        );
+      }
+    } else {
+      $this->path= $encode ? $this->escape($value, '@+/:', 'rawurlencode') : $value;
+    }
     return $this;
   }
 

--- a/src/test/php/util/unittest/URICreationTest.class.php
+++ b/src/test/php/util/unittest/URICreationTest.class.php
@@ -216,6 +216,27 @@ class URICreationTest extends \unittest\TestCase {
   }
 
   #[@test, @values([
+  #  [[], ''],
+  #  [['/test'], '/test'],
+  #  [['/test/'], '/test/'],
+  #  [['/test', 'child/'], '/test/child/'],
+  #  [['/test', 'child'], '/test/child'],
+  #  [['/test/', 'child'], '/test/child'],
+  #  [['/test//', 'child'], '/test/child'],
+  #  [['/test', '/child'], '/test/child'],
+  #  [['/test/', '/child'], '/test/child'],
+  #  [['/test/', '//child'], '/test/child'],
+  #  [['/test//', '//child'], '/test/child'],
+  #  [['/test', 'child', 'sub'], '/test/child/sub'],
+  #])]
+  public function combining_path($paths, $expected) {
+    $this->assertEquals(
+      'http://example.com'.$expected,
+      (string)(new URI('http://example.com'))->using()->path($paths)->create()
+    );
+  }
+
+  #[@test, @values([
   #  'https://example.com/login?service=http%3A%2F%2Flocalhost',
   #  'https://example.com/login?service=http%3A%2F%2Flocalhost%2F%3Fservice%3D%2521ncoded',
   #])]


### PR DESCRIPTION
```php
// Current way - if you forget the trim calls, you might end up with // in the URL
$joined= rtrim($this->base->path(), '/').'/'.ltrim($request->uri()->path(), '/');
$uri= $this->base->using()->path($joined)->create();

// New
$uri= $this->base->using()->path([$this->base->path(), $request->uri()->path()])->create();
```