### PR TITLE
Add util.URI::base() method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     name: PHP ${{ matrix.php-versions }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.php-versions == '8.1' }}
+    continue-on-error: ${{ matrix.php-versions == '8.2' }}
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
         os: [ubuntu-latest, windows-latest]
 
     steps:
@@ -51,7 +51,7 @@ jobs:
 
     - name: Install dependencies
       run: >
-        curl -sSL https://baltocdn.com/xp-framework/xp-runners/distribution/downloads/e/entrypoint/xp-run-8.5.1.sh > xp-run &&
+        curl -sSL https://baltocdn.com/xp-framework/xp-runners/distribution/downloads/e/entrypoint/xp-run-8.6.2.sh > xp-run &&
         composer install --prefer-dist &&
         echo "vendor/autoload.php" > composer.pth
 

--- a/src/test/php/util/unittest/URITest.class.php
+++ b/src/test/php/util/unittest/URITest.class.php
@@ -94,6 +94,21 @@ class URITest {
     Assert::equals(8080, (new URI('http://example.com:8080'))->port());
   }
 
+  #[Test, Values('hierarchicalUris')]
+  public function hierarchical_base($uri) {
+    Assert::equals($uri->using()->path(null)->query(null)->create(), $uri->base());
+  }
+
+  #[Test, Values('opaqueUris')]
+  public function opaque_base($uri) {
+    Assert::equals($uri->using()->query(null)->create(), $uri->base());
+  }
+
+  #[Test, Expect(IllegalStateException::class), Values('relativeUris')]
+  public function relative_base($uri) {
+    $uri->base();
+  }
+
   #[Test]
   public function without_path() {
     Assert::equals(null, (new URI('http://example.com'))->path());
@@ -434,5 +449,15 @@ class URITest {
   #[Test, Expect(IllegalStateException::class), Values(['http://example.com', 'tel:+1-816-555-1212'])]
   public function not_representable_as_path($uri) {
     (new URI($uri))->asPath();
+  }
+
+  #[Test, Values(['http://user:pass@example.com/', 'http://user@example.com/', 'http://example.com/'])]
+  public function anonymous($input) {
+    Assert::equals(new URI('http://example.com/'), (new URI($input))->anonymous());
+  }
+
+  #[Test, Values(['http://example.com/', 'http://user@example.com/', 'http://user:pass@example.com/'])]
+  public function authenticated($input) {
+    Assert::equals(new URI('http://test:secret@example.com/'), (new URI($input))->authenticated('test', 'secret'));
   }
 }


### PR DESCRIPTION
Returns the base URI. For opaque URIs, this is the scheme and the path; for hierarchical URIs, this is the scheme and authority:

- `mailto:test@example.com?subject=Test` -> `mailto:test@example.com`
- `http://localhost:443/test?of=example` -> `http://localhost:443`

For relative URIs, an exception is raised.